### PR TITLE
Added ability to retrieve city_geoname_id

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,7 @@ Version 0.6.1 [WIP]
 DEVELOPMENT
 * The vignette, and documentation of the maxmind function, have been improved to make explicit
 the datasets rgeolocate ships with (#25)
+* Added ability to retrieve city_geoname_id from maxmind databases
 
 Version 0.6.0
 -------------------------------------------------------------------------

--- a/R/maxmind.R
+++ b/R/maxmind.R
@@ -14,6 +14,7 @@
 #'  \item{country_code}{: the ISO code of the country. Requires a country or city database.}
 #'  \item{region_name}{: the English-language name of the region. Requires a city database.}
 #'  \item{city_name}{: the English-language name of the city. Requires a city database.}
+#'  \item{city_geoname_id}{: a unique ID representing a city. Requires a city database. }
 #'  \item{timezone}{: the tzdata-compatible time zone. Requires a city database.}
 #'  \item{longitude}{: latitude of location. Requires a city database.}
 #'  \item{latitude}{: longitude of location. Requires a city database.}
@@ -30,8 +31,8 @@
 #'yourself - for CRAN and/or copyright reasons, depending, we cannot include them.
 #'
 #'In the event that the file provided does not have the field you have requested (or the IP address does
-#'not have an entry for that field), the string "Unknown" (or NA for a numeric field such as latitude or
-#'longitude) will be returned instead. In the event that the IP
+#'not have an entry for that field), the string "Unknown" (or NA for a numeric field such latitude,
+#'longitude, or city_geoname_id) will be returned instead. In the event that the IP
 #'address doesn't have an entry in the file at all, "Unknown"/NA will be returned for every field.
 #'
 #'@examples
@@ -42,7 +43,7 @@
 #'@export
 maxmind <- function(ips, file, fields = c("continent_name", "country_name", "country_code")){
   possible_fields <- c("continent_name", "country_name", "country_code", "region_name",
-                       "city_name", "timezone", "connection", "latitude", "longitude")
+                       "city_name", "timezone", "connection", "city_geoname_id", "latitude", "longitude")
   
   if(!all(fields %in% possible_fields)){
     warning("Some field names you have provided are not supported and no data will be retrieved for them. \nThe

--- a/man/maxmind.Rd
+++ b/man/maxmind.Rd
@@ -19,6 +19,7 @@ maxmind(ips, file, fields = c("continent_name", "country_name",
  \item{country_code}{: the ISO code of the country. Requires a country or city database.}
  \item{region_name}{: the English-language name of the region. Requires a city database.}
  \item{city_name}{: the English-language name of the city. Requires a city database.}
+ \item{city_geoname_id}{: a unique ID representing a city. Requires a city database. }
  \item{timezone}{: the tzdata-compatible time zone. Requires a city database.}
  \item{longitude}{: latitude of location. Requires a city database.}
  \item{latitude}{: longitude of location. Requires a city database.}
@@ -41,8 +42,8 @@ you need city-level data, or other MaxMind databases, you'll need to download th
 yourself - for CRAN and/or copyright reasons, depending, we cannot include them.
 
 In the event that the file provided does not have the field you have requested (or the IP address does
-not have an entry for that field), the string "Unknown" (or NA for a numeric field such as latitude or
-longitude) will be returned instead. In the event that the IP
+not have an entry for that field), the string "Unknown" (or NA for a numeric field such latitude,
+longitude, or city_geoname_id) will be returned instead. In the event that the IP
 address doesn't have an entry in the file at all, "Unknown"/NA will be returned for every field.
 }
 \examples{

--- a/src/maxmind.h
+++ b/src/maxmind.h
@@ -21,6 +21,8 @@ private:
   std::vector < std::string > region_name(MMDB_s *data, std::vector < std::string >& ip_addresses);
   
   std::vector < std::string > city_name(MMDB_s *data, std::vector < std::string >& ip_addresses);
+
+  std::vector < int > city_geoname_id(MMDB_s *data, std::vector < std::string >& ip_addresses);
   
   std::vector < std::string > timezone(MMDB_s *data, std::vector < std::string >& ip_addresses);
   

--- a/tests/testthat/test_maxmind.R
+++ b/tests/testthat/test_maxmind.R
@@ -33,34 +33,37 @@ test_that("A df of the right values is returned", {
 })
 
 
-test_that("Longitude and latitude can be retrieved", {
+test_that("Longitude, latitude, and geoname_id can be retrieved", {
   test_files <- c("GeoIP2-City-Test.mmdb",
                   "GeoIP2-Precision-City-Test.mmdb")
   for (test_file in test_files) {
     infile <- system.file("extdata", test_file, package = "rgeolocate")
     results <- maxmind("2.125.160.216", infile, c("continent_name", "country_code",
                                        "country_name", "city_name",
-                                       "latitude", "longitude"))
+                                       "latitude", "longitude", "city_geoname_id"))
     expect_that(results$continent_name[1], equals("Europe"))
     expect_that(results$country_code[1], equals("GB"))
     expect_that(results$country_name[1], equals("United Kingdom"))
     expect_that(results$city_name[1], equals("Boxford"))
     expect_that(results$latitude[1], equals(51.75))
     expect_that(results$longitude[1], equals(-1.25))
+    expect_that(results$city_geoname_id[1], equals(2655045))
   }
 })
 
 
-test_that("Unknown longitude and latitude are returned as NA", {
+test_that("Unknown longitude, latitude and geoname_id are returned as NA", {
   test_files <- c("GeoIP2-Anonymous-IP-Test.mmdb",
                   "GeoLite2-Country.mmdb")
   for (test_file in test_files) {
     infile <- system.file("extdata", test_file, package = "rgeolocate")
     results <- maxmind("2.125.160.216", infile, c("continent_name", "country_code",
                                                   "country_name", "city_name",
-                                                  "latitude", "longitude"))
+                                                  "latitude", "longitude",
+                                                  "city_geoname_id"))
     expect_that(is.na(results$latitude[1]), is_true())
     expect_that(is.na(results$longitude[1]), is_true())
+    expect_that(is.na(results$city_geoname_id[1]), is_true())
   }
 })
 


### PR DESCRIPTION
Added ability to retrieve city_geoname_id, which uniquely identifies a city. Among other uses, this can help disambiguate when multiple cities in the same country have the same name. (See geonames.org for more).

Added tests as well.

(This required adding an additional C++ function mmdb_getint).
