### PR TITLE
longer delay for ip_api - API limit is now 150 requests/min

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+Version 0.8.0
+-------------------------------------------------------------------------
+
+DEVELOPMENT
+* Using longer delay for requests to ip-api.com due to new API rate limits.
+
 Version 0.7.0
 -------------------------------------------------------------------------
 

--- a/R/ip_api.R
+++ b/R/ip_api.R
@@ -1,6 +1,6 @@
 query_ip_api <- function(ip, sleep){
   if(sleep){
-    Sys.sleep(0.10)
+    Sys.sleep(0.40)
   }
   url <- paste0("http://ip-api.com/json/", ip)
   
@@ -25,8 +25,8 @@ query_ip_api <- function(ip, sleep){
 #'@param as_data_frame whether to return the results as a data.frame or not.
 #'Set to TRUE by default.
 #'
-#'@param delay whether or not to delay each request by 100ms. ip-api.com has a
-#'maximum threshold of 2,500 requests a minute; if you're parallelising calls, you
+#'@param delay whether or not to delay each request by 400ms. ip-api.com has a
+#'maximum threshold of 150 requests a minute; if you're parallelising calls, you
 #'might run into this. \code{delay} allows you to set a delay between requests, taking
 #'advantage of parallelisation while avoiding running into this threshold. Set to
 #'FALSE by default


### PR DESCRIPTION
See http://ip-api.com/docs/.  The problem is that the code assumes a limit of 2500 requests/min while the current limit is 150.  I'm currently getting blocked when using the old delay value.  The new delay of 0.4 means that 150 requests would take 60 seconds, so you're guaranteed to stay under the limit. 
