### PR TITLE
Added ability to retrieve isp and organization name from MaxMind ISP database

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@ Version 0.8.0
 
 DEVELOPMENT
 * Using longer delay for requests to ip-api.com due to new API rate limits.
+* Allow retrieving isp and organization with an ISP database
 
 Version 0.7.0
 -------------------------------------------------------------------------

--- a/R/maxmind.R
+++ b/R/maxmind.R
@@ -18,6 +18,8 @@
 #'  \item{timezone}{: the tzdata-compatible time zone. Requires a city database.}
 #'  \item{longitude}{: latitude of location. Requires a city database.}
 #'  \item{latitude}{: longitude of location. Requires a city database.}
+#'  \item{isp}{: name of ISP. Requires an ISP database.}
+#'  \item{organization}{: name of organization. Requires an ISP database.}
 #'  \item{connection}{: the type of internet connection. Requires a connection type/netspeed database.}
 #'}
 #'@details
@@ -42,7 +44,8 @@
 #'@export
 maxmind <- function(ips, file, fields = c("continent_name", "country_name", "country_code")){
   possible_fields <- c("continent_name", "country_name", "country_code", "region_name",
-                       "city_name", "timezone", "connection", "city_geoname_id", "latitude", "longitude")
+                       "city_name", "timezone", "connection", "city_geoname_id", "latitude", "longitude",
+                       "isp", "organization")
   
   if(!all(fields %in% possible_fields)){
     warning("Some field names you have provided are not supported and no data will be retrieved for them. \nThe

--- a/src/maxmind.cpp
+++ b/src/maxmind.cpp
@@ -139,6 +139,14 @@ CharacterVector maxmind_bindings::connection(MMDB_s *data, CharacterVector ip_ad
   return mmdb_getstring(data, ip_addresses, "connection_type", NULL);
 }
 
+CharacterVector maxmind_bindings::isp(MMDB_s *data, CharacterVector ip_addresses){
+  return mmdb_getstring(data, ip_addresses, "isp", NULL);
+}
+
+CharacterVector maxmind_bindings::organization(MMDB_s *data, CharacterVector ip_addresses){
+  return mmdb_getstring(data, ip_addresses, "organization", NULL);
+}
+
 std::vector < int > maxmind_bindings::city_geoname_id(MMDB_s *data, CharacterVector ip_addresses){
   return mmdb_getint(data, ip_addresses, "city", "geoname_id", NULL);
 }
@@ -176,6 +184,10 @@ List maxmind_bindings::lookup(CharacterVector ip_addresses, MMDB_s *mmdb_set,
       output.push_back(longitude(mmdb_set, ip_addresses));
     } else if(fields[i] == "connection"){
       output.push_back(connection(mmdb_set, ip_addresses));
+    } else if(fields[i] == "organization"){
+      output.push_back(organization(mmdb_set, ip_addresses));
+    } else if(fields[i] == "isp"){
+      output.push_back(isp(mmdb_set, ip_addresses));
     } else if (fields[i] == "city_geoname_id") {
       output.push_back(city_geoname_id(mmdb_set, ip_addresses));
     }

--- a/src/maxmind.h
+++ b/src/maxmind.h
@@ -28,6 +28,10 @@ private:
   
   CharacterVector connection(MMDB_s *data, CharacterVector ip_addresses);
 
+  CharacterVector isp(MMDB_s *data, CharacterVector ip_addresses);
+  
+  CharacterVector organization(MMDB_s *data, CharacterVector ip_addresses);
+  
   std::vector < double > latitude(MMDB_s *data, CharacterVector ip_addresses);
 
   std::vector < double > longitude(MMDB_s *data, CharacterVector ip_addresses);


### PR DESCRIPTION
I've had the need to compare addresses to ISP databases rather than just location, and the below fix allows retrieving them. (Since connection is included, I'm hoping not all have to be strictly location fields?)

Thanks!