### PR TITLE
Add location's accuracy_radius

### DIFF
--- a/R/maxmind.R
+++ b/R/maxmind.R
@@ -19,6 +19,7 @@
 #'  \item{timezone}{: the tzdata-compatible time zone. Requires a city database.}
 #'  \item{longitude}{: longitude of location. Requires a city database.}
 #'  \item{latitude}{: latitude of location. Requires a city database.}
+#'  \item{accuracy_radius}{: estimated accurracy radius (in km) of location. Requires a city database.}
 #'  \item{isp}{: name of ISP. Requires an ISP database.}
 #'  \item{organization}{: name of organization. Requires an ISP database.}
 #'  \item{asn}{: Autonomous System Number. Requires an ISP database.}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -2,7 +2,7 @@ rgeo_env <- new.env(parent = emptyenv())
 
 .onLoad <- function(...) {
   maxmind_tags <- c("continent_name", "country_name", "country_code", "region_name",
-                    "city_name", "timezone", "connection", "city_geoname_id", "latitude", "longitude",
+                    "city_name", "timezone", "connection", "city_geoname_id", "latitude", "longitude", "accuracy_radius",
                     "isp", "organization", "asn", "aso", "postcode","city_metro_code")
   ipinfo_tags <- c("hostname", "city", "region", "country",
                    "loc", "org", "postal", "phone")

--- a/src/maxmind.cpp
+++ b/src/maxmind.cpp
@@ -210,6 +210,10 @@ NumericVector maxmind_bindings::longitude(MMDB_s *data, CharacterVector ip_addre
   return mmdb_getdouble(data, ip_addresses, "location", "longitude", NULL);
 }
 
+IntegerVector maxmind_bindings::accuracy_radius(MMDB_s *data, CharacterVector ip_addresses){
+  return mmdb_getint16(data, ip_addresses, "location", "accuracy_radius", NULL);
+}
+
 List maxmind_bindings::lookup(CharacterVector ip_addresses, MMDB_s *mmdb_set,
                                                      std::vector < std::string > fields){
   
@@ -233,6 +237,8 @@ List maxmind_bindings::lookup(CharacterVector ip_addresses, MMDB_s *mmdb_set,
       output.push_back(latitude(mmdb_set, ip_addresses));
     } else if(fields[i] == "longitude"){
       output.push_back(longitude(mmdb_set, ip_addresses));
+    } else if(fields[i] == "accuracy_radius"){
+      output.push_back(accuracy_radius(mmdb_set, ip_addresses));
     } else if(fields[i] == "connection"){
       output.push_back(connection(mmdb_set, ip_addresses));
     } else if(fields[i] == "organization"){

--- a/src/maxmind.h
+++ b/src/maxmind.h
@@ -44,6 +44,8 @@ private:
 
   NumericVector longitude(MMDB_s *data, CharacterVector ip_addresses);
   
+  IntegerVector accuracy_radius(MMDB_s *data, CharacterVector ip_addresses);
+  
   List lookup(CharacterVector ip_addresses, MMDB_s *mmdb_set, std::vector < std::string > fields);
   
 public:


### PR DESCRIPTION
This field is present in MaxMind cities DB (both the free GeoLite2 City and the proprietary GeoIP City databases).
Unfortunately, I could'nt add it to the test_that tests, considering that the current example DBs inside `inst/` do not contain this field.
I tested it both with a proprietary MM GeoIP2 City and the free GeoLite2 City db, and it worked in both case for the already tested adress.